### PR TITLE
SCRUM-20: feature: add delete implementation & tests: delete tests

### DIFF
--- a/crud/task.py
+++ b/crud/task.py
@@ -2,7 +2,7 @@ from typing import Sequence, Optional
 import pytz
 from datetime import datetime
 from dateutil import parser
-from fastapi import Depends
+from fastapi import Depends, HTTPException, status
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 from models.task import Task
@@ -129,3 +129,16 @@ def update_task(task_id: str, task: TaskUpdate, db: Session = Depends(get_db), t
             "Error: Could not update the task due to a database integrity issue.") from exc
 
     return db_task
+
+def delete_task_by_id(task_id: str, db: Session = Depends(get_db)) -> bool:
+    """
+    Delete a task by its unique identifier.
+    """
+    try:
+        db_task = get_task_by_id(task_id, db)
+        db.delete(db_task)
+        db.commit()
+        return True
+    except ValueError as val_err:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Task not found.") from val_err
+

--- a/tests/crud/test_task.py
+++ b/tests/crud/test_task.py
@@ -1,6 +1,6 @@
 import pytest
 from sqlalchemy.orm import sessionmaker
-from sqlalchemy.exc import IntegrityError
+from fastapi import HTTPException, status
 from sqlalchemy import create_engine
 from datetime import datetime, timedelta
 from testcontainers.mysql import MySqlContainer
@@ -366,5 +366,9 @@ def test_delete_task_not_found(test_db):
     Test deletion of a task that does not exist.
     """
     non_existent_task_id = "non_existent_task_id"
-    with pytest.raises(ValueError, match="Task not found."):
+    with pytest.raises(HTTPException) as exc_info:
         delete_task_by_id(task_id=non_existent_task_id, db=test_db)
+
+    # Verifica se a exceção capturada é 404
+    assert exc_info.value.status_code == status.HTTP_404_NOT_FOUND
+    assert exc_info.value.detail == "Task not found."

--- a/tests/crud/test_task.py
+++ b/tests/crud/test_task.py
@@ -8,7 +8,7 @@ from models.task import Task as TaskModel
 from models.user import User as UserModel
 from schemas.task import TaskCreate, TaskUpdate, TaskState
 from pydantic import ValidationError
-from crud.task import create_task, get_tasks_by_user_id, get_task_by_id, update_task
+from crud.task import create_task, get_tasks_by_user_id, get_task_by_id, update_task, delete_task_by_id
 import logging
 from db.database import get_db
 from main import app
@@ -340,3 +340,31 @@ def test_update_task_with_invalid_state(test_db, test_user):
         update_task(task_id=created_task.id, task=TaskUpdate(**update_data), db=test_db)
 
     assert "Input should be 'to_do', 'in_progress' or 'done'" in str(exc_info.value)
+
+def test_delete_task_success(test_db, test_user):
+    """
+    Test successful deletion of a task.
+    """
+    # Criação da tarefa
+    task_data = TaskCreate(
+        title="Task to be deleted",
+        description="This task will be deleted in the test",
+        deadline=datetime.now() + timedelta(days=1),
+        priority="medium",
+    )
+    created_task = create_task(task=task_data, db=test_db, user_id=str(test_user.id))
+
+    # Deletar a tarefa
+    delete_successful = delete_task_by_id(task_id=created_task.id, db=test_db)
+
+    # Verificar se a tarefa foi excluída
+    assert delete_successful is True
+    assert test_db.query(TaskModel).filter(TaskModel.id == created_task.id).first() is None
+
+def test_delete_task_not_found(test_db):
+    """
+    Test deletion of a task that does not exist.
+    """
+    non_existent_task_id = "non_existent_task_id"
+    with pytest.raises(ValueError, match="Task not found."):
+        delete_task_by_id(task_id=non_existent_task_id, db=test_db)


### PR DESCRIPTION
This pull request introduces functionality to delete tasks, including the necessary API endpoint, error handling, and tests. The most important changes include adding the `delete_task_by_id` function, creating the corresponding API endpoint, and implementing tests for task deletion.

### New Functionality:
* **Task Deletion Functionality**:
  - Added `delete_task_by_id` function in `crud/task.py` to handle task deletion by ID.
  - Included new imports for `HTTPException` and `status` in `crud/task.py` to handle errors.
  - Added `delete_task` API endpoint in `routers/task.py` to delete a task by ID for an authenticated user.
  - Included new imports for `delete_task_by_id` in `routers/task.py`.

### Tests:
* **Unit Tests for Task Deletion**:
  - Added `test_delete_task_success` to verify successful task deletion in `tests/crud/test_task.py`.
  - Added `test_delete_task_not_found` to handle deletion of non-existent tasks in `tests/crud/test_task.py`.
  - Added `test_delete_task_success`, `test_delete_task_not_found`, and `test_delete_task_forbidden` to verify task deletion scenarios in `tests/routers/test_task.py`.

These changes ensure that tasks can be deleted through the API, with appropriate error handling and thorough testing.