### PR TITLE
SCRUM-21: feature: add get_tasks_by_user endpoint and tested

### DIFF
--- a/tests/crud/test_task.py
+++ b/tests/crud/test_task.py
@@ -213,7 +213,6 @@ def test_get_task_by_invalid_id(test_db):
     Test retrieving a task with a non-existent ID, which should raise a ValueError.
     """
     invalid_task_id = "non_existent_task_id"
-
     with pytest.raises(ValueError, match="Task not found."):
         get_task_by_id(task_id=invalid_task_id, db=test_db)
 
@@ -368,7 +367,5 @@ def test_delete_task_not_found(test_db):
     non_existent_task_id = "non_existent_task_id"
     with pytest.raises(HTTPException) as exc_info:
         delete_task_by_id(task_id=non_existent_task_id, db=test_db)
-
-    # Verifica se a exceção capturada é 404
-    assert exc_info.value.status_code == status.HTTP_404_NOT_FOUND
+    assert exc_info.value.status_code == 404
     assert exc_info.value.detail == "Task not found."


### PR DESCRIPTION
This pull request includes several changes to improve error handling and add new functionality for retrieving tasks by user. The most important changes include adding new exception handling, implementing a new endpoint for retrieving tasks by user, and updating test cases to cover these new changes.

**Error Handling Improvements:**

* Added a `ValueError` exception to the `get_task` function to handle cases where a task is not found, logging the error and raising an `HTTPException` with a 404 status code. (`routers/task.py`, [routers/task.pyR79-R82](diffhunk://#diff-34a85b9525bb969b96c04301cd37cd66bb907856626d02f7b433ffee46539f86R79-R82))

**New Functionality:**

* Implemented a new endpoint `/tasks` to retrieve all tasks for the authenticated user, including error handling for user not found and unexpected errors. (`routers/task.py`, [routers/task.pyR167-R193](diffhunk://#diff-34a85b9525bb969b96c04301cd37cd66bb907856626d02f7b433ffee46539f86R167-R193))

**Test Case Updates:**

* Updated the `test_get_task_by_invalid_id` test to match the new `ValueError` message "Task not found." (`tests/crud/test_task.py`, [tests/crud/test_task.pyL216](diffhunk://#diff-869cf89a115f7095b5cc50b9907343025db372d394c8cee623db2074829f0b01L216))
* Simplified the `test_delete_task_not_found` test by removing unnecessary comments and ensuring it checks for a 404 status code. (`tests/crud/test_task.py`, [tests/crud/test_task.pyL371-R370](diffhunk://#diff-869cf89a115f7095b5cc50b9907343025db372d394c8cee623db2074829f0b01L371-R370))
* Added new test cases to validate the new endpoint `/tasks`, including tests for successful retrieval, no tasks found, user not found, and unexpected errors. (`tests/routers/test_task.py`, [tests/routers/test_task.pyR488-R584](diffhunk://#diff-d99d4083946f4e27f9738a634dec7d1a54d041f94ec4065d8490bea0850d6b93R488-R584))