### PR TITLE
SCRUM-29: fix: update without deadline is setted is now fixed

### DIFF
--- a/crud/task.py
+++ b/crud/task.py
@@ -102,7 +102,7 @@ def update_task(task_id: str, task: TaskUpdate, db: Session = Depends(get_db), t
         raise ValueError("Invalid task state.")
 
     # Conversão de `deadline`, se fornecido
-    if 'deadline' in task_data:
+    if 'deadline' in task_data and task_data['deadline'] is not None:
         if isinstance(task_data['deadline'], str):
             try:
                 task_data['deadline'] = parser.parse(task_data['deadline'])


### PR DESCRIPTION
This pull request includes a minor change to the `update_task` function in the `crud/task.py` file. The change ensures that the `deadline` field is only processed if it is not `None`.

* [`crud/task.py`](diffhunk://#diff-982081e8c6eac13fc8776804bf95157890e9ede851bf73f45bf88b71175a8ba0L105-R105): Modified the `update_task` function to check if `deadline` is not `None` before processing it.